### PR TITLE
Add possibility to pass `--whitespace-after-token` flag to grock 

### DIFF
--- a/tasks/grock.js
+++ b/tasks/grock.js
@@ -28,6 +28,7 @@ module.exports = function(grunt) {
       index: options.index ||'Readme.md',
       root: options.root || '.',
       github: options.github || false,
+      'whitespace-after-token': options.whitespaceAfterToken || false,
       start: process.hrtime()
     };
 


### PR DESCRIPTION
ignore comments like /*jslint node:true*/
